### PR TITLE
Fix that IndexOutOfBoundsException happens when using varargs

### DIFF
--- a/org.jtool.eclipse/src/org/jtool/eclipse/model/java/JavaMethodCall.java
+++ b/org.jtool.eclipse/src/org/jtool/eclipse/model/java/JavaMethodCall.java
@@ -384,7 +384,7 @@ public class JavaMethodCall extends JavaExpression {
      * @return the string of the found argument type, <code>null</code> if no argument was found
      */
     public String getArgumentType(int pos) {
-        return argumentTypes.get(pos);
+        return argumentTypes.get(Math.min(pos, argumentTypes.size() - 1));
     }
     
     /**

--- a/org.jtool.eclipse/src/org/jtool/eclipse/model/pdg/SDGFactory.java
+++ b/org.jtool.eclipse/src/org/jtool/eclipse/model/pdg/SDGFactory.java
@@ -206,10 +206,10 @@ public class SDGFactory {
      * @param callee the CFG entry node corresponding to the called method
      */
     private static void connectParameters(SDG sdg, CFGMethodCall caller, CFGMethodEntry callee) {
-        for (int ordinal = 0; ordinal < callee.getFormalIns().size(); ordinal++) {
+        for (int ordinal = 0; ordinal < caller.getActualIns().size(); ordinal++) {
             
             CFGParameter ain = caller.getActualIn(ordinal);
-            CFGParameter fin = callee.getFormalIn(ordinal);
+            CFGParameter fin = callee.getFormalIn(Math.min(ordinal, callee.getFormalIns().size() - 1));
             
             JavaVariableAccess jv = fin.getUseVariables().get(0);
             ParameterEdge pinedge = new ParameterEdge(ain.getPDGNode(), fin.getPDGNode(), jv);


### PR DESCRIPTION
IndexOutOfBoundsException is thrown when applying CFG/PDG analysis to the following code. This is due to the difference of the numbers of arguments and parameters.

```
class C {
  void foo(String... args) {}
  void bar() {
    foo("1", "2");
  }
}
```
