### PR TITLE
Fix the inconsistency of srcNodes/dstNodes when invoking setSrcNode/setDstNode

### DIFF
--- a/org.jtool.eclipse/src/org/jtool/eclipse/model/graph/GraphEdge.java
+++ b/org.jtool.eclipse/src/org/jtool/eclipse/model/graph/GraphEdge.java
@@ -112,8 +112,10 @@ public class GraphEdge extends GraphElement {
      */
     public void setSrcNode(GraphNode node) {
         src.removeOutgoingEdge(this);
+        dst.removeIncomingEdge(this);
         src = node;
         src.addOutgoingEdge(this);
+        dst.addIncomingEdge(this);
     }
     
     /**
@@ -121,8 +123,10 @@ public class GraphEdge extends GraphElement {
      * @param node the destination node
      */
     public void setDstNode(GraphNode node) {
+        src.removeOutgoingEdge(this);
         dst.removeIncomingEdge(this);
         dst = node;
+        src.addOutgoingEdge(this);
         dst.addIncomingEdge(this);
     }
     


### PR DESCRIPTION
Since GraphEdge#setSrcNode and GraphEdge#setDstNode do not update the neighbor information (srcNodes and dstNodes) of the unmodified side of nodes, it causes inconsistency.
